### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ terraform {
 
 provider omglol {
   api_key = "<omg.lol API key>" // Alternatively set the OMGLOL_API_KEY env variable
-  email = "<email address>" // Alternatively set the OMGLOL_USER_EMAIL env variable
+  user_email = "<email address>" // Alternatively set the OMGLOL_USER_EMAIL env variable
 }
 ```
 


### PR DESCRIPTION
Minor typo:

provider credential line had a typo, requires `user_email` not `email`